### PR TITLE
add a pre-commit hook for validating character sets as utf-8 (or ascii)

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+git ls-files -mz -- | while IFS= read -r -d $'\0' FILE; do
+	FENC=$(file -b --mime-encoding "$FILE")
+	case "$FENC" in
+		'us-ascii' | 'utf-8')
+			#echo "$FILE is ok"
+		;;
+		*)
+			echo "Encoding is $FENC for $FILE"
+			exit 1
+		;;
+	esac
+done


### PR DESCRIPTION
you have to manually copy this to your .git/hooks/ directory for this to work

if we move to a git provider that supports hooks (e.g. gitlab) for the main repo, we can make something run on the server